### PR TITLE
Make mask Urls unique

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -27,17 +27,18 @@ title: Welcome to Middleman
         const length = tempPath.getTotalLength();
         document.body.removeChild(tempSvg);
 
+        let maskId = crypto.randomUUID();
         const newSVG = `
             <svg xmlns="http://www.w3.org/2000/svg">
               <defs>
-                <mask id="path-mask">
+                <mask id="${maskId}">
                   <g fill="white">
                     ${primaryPathsD}
                   </g>
                 </mask>
               </defs>
               <path class="mask" d="${secondaryPathD}"
-                    mask="url(#path-mask)" stroke="black" stroke-width="2" fill="none"
+                    mask="url(#${maskId})" stroke="black" stroke-width="2" fill="none"
                     stroke-dasharray="${length}" stroke-dashoffset="${length}">
               </path>
             </svg>


### PR DESCRIPTION
I couldn't get this running on a deploy. Lost my touch with the ruby 😉

Looks like it's trying to use the same path-mask for all the svgs. Because you set the id and then that can never change. This just sets the id to a random value.